### PR TITLE
fix: fix bar going out of bounds

### DIFF
--- a/src/bar.c
+++ b/src/bar.c
@@ -18,7 +18,7 @@ void barLeft(Bar *bar) {
 
 // Moves the paddle right one grid unit.
 void barRight(Bar *bar) {
-  if (bar->pos + SIZE < RIGHT_COLUMN_BOUND) {
+  if (bar->pos + (SIZE * bar->width) < RIGHT_COLUMN_BOUND) {
     bar->pos = getPixel((bar->pos / SIZE) + 1);
   }
 }


### PR DESCRIPTION
The bar would go out of bounds on the right side due to an incorrect position measure being calculated in the collision check.

Fixes #5.